### PR TITLE
added query endpoint

### DIFF
--- a/src/clickhouse/createClient.ts
+++ b/src/clickhouse/createClient.ts
@@ -1,21 +1,30 @@
-import { createClient } from "@clickhouse/client-web";
-import { ping } from "./ping.js";
+import { createClient as createClientWeb } from "@clickhouse/client-web";
 import { APP_NAME, config } from "../config.js";
+import { ping } from "./ping.js";
 
-const client = createClient({
+function createClient(readonly = false) {
+  const client = createClientWeb({
     ...config,
     clickhouse_settings: {
       wait_for_async_insert: config.waitForAsyncInsert, // 0
       async_insert: config.asyncInsert, // 1
       allow_experimental_object_type: 1,
+      readonly: readonly ? "1" : "0",
     },
     application: APP_NAME,
-})
+  });
 
-// These overrides should not be required but the @clickhouse/client-web instance
-// does not work well with Bun's implementation of Node streams.
-// https://github.com/oven-sh/bun/issues/5470
-client.command = client.exec;
-client.ping = ping;
+  // These overrides should not be required but the @clickhouse/client-web instance
+  // does not work well with Bun's implementation of Node streams.
+  // https://github.com/oven-sh/bun/issues/5470
+  client.command = client.exec;
+  client.ping = ping;
+
+  return client;
+}
+
+const client = createClient();
+const readOnlyClient = createClient(true);
 
 export default client;
+export { readOnlyClient };

--- a/src/fetch/POST.ts
+++ b/src/fetch/POST.ts
@@ -2,8 +2,15 @@ import { handleSinkRequest } from "../clickhouse/handleSinkRequest.js";
 import { sink_request_errors, sink_requests } from "../prometheus.js";
 import { BodySchema } from "../schemas.js";
 import signatureEd25519 from "../webhook/signatureEd25519.js";
+import { query } from "./query.js";
 
 export default async function (req: Request) {
+  const { pathname } = new URL(req.url);
+
+  if (pathname === "/query") {
+    return query(req);
+  }
+
   // validate Ed25519 signature
   const text = await req.text();
   const signatureError = await signatureEd25519(req, text);

--- a/src/fetch/openapi.ts
+++ b/src/fetch/openapi.ts
@@ -126,6 +126,20 @@ export default new OpenApiBuilder()
       responses: PUT_RESPONSES,
     },
   })
+  .addPath("/query", {
+    post: {
+      tags: [TAGS.USAGE],
+      summary: "Execute queries against the database in read-only mode",
+      requestBody: {
+        content: {
+          "text/plain": {
+            schema: { type: "string", example: "SELECT * FROM foo" },
+          },
+        },
+      },
+      responses: { 200: { description: "query result", content: { "application/json": {} } } },
+    },
+  })
   .addPath("/health", {
     get: {
       tags: [TAGS.HEALTH],

--- a/src/fetch/query.ts
+++ b/src/fetch/query.ts
@@ -1,0 +1,16 @@
+import { readOnlyClient } from "../clickhouse/createClient.js";
+
+export async function query(req: Request): Promise<Response> {
+  try {
+    const query = await req.text();
+    const result = await readOnlyClient.query({ query, format: "JSONEachRow" });
+    const data = await result.json();
+
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response("Bad request: " + err, { status: 400 });
+  }
+}


### PR DESCRIPTION
Added `POST /query` with a readonly client. The query is in plain text in the body.
Solves #45.