### PR TITLE
Unparsed json table updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ They are converted to SQL following these rules before being executed. The avail
 
 No schema is required to store data in ClickHouse. Everything can be stored in `unparsed_json` (see [database structure](#database-structure)).
 
-The user **must** build custom [views](https://clickhouse.com/docs/en/guides/developer/cascading-materialized-views) to transform the data according to their needs. Further details are available in [ClickHouse's documentation](https://clickhouse.com/docs/en/integrations/data-formats/json#using-materialized-views).
+The user **should** build custom [views](https://clickhouse.com/docs/en/guides/developer/cascading-materialized-views) to transform the data according to their needs. Further details are available in [ClickHouse's documentation](https://clickhouse.com/docs/en/integrations/data-formats/json#using-materialized-views). It is also suggested to clean the `unparsed_json` table once it has been processed.
 
 </details>
 
@@ -105,6 +105,7 @@ Options:
   --wait-for-insert <boolean>   https://clickhouse.com/docs/en/operations/settings/settings#wait-for-async-insert (choices: "0", "1", default: 0, env: WAIT_FOR_INSERT)
   --max-buffer-size <number>    Maximum insertion batch size (default: 10_000, env: MAX_BUFFER_SIZE)
   --insertion-delay <number>    Delay between batch insertions (in ms) (default: 2000, env: INSERTION_DELAY)
+  --allow-unparsed <boolean>    Enable storage in 'unparsed_json' table (default: false, env: ALLOW_UNPARSED)
   -h, --help                    display help for command
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export const DEFAULT_ASYNC_INSERT = 1;
 export const DEFAULT_WAIT_FOR_ASYNC_INSERT = 0;
 export const DEFAULT_MAX_BUFFER_SIZE = 10_000;
 export const DEFAULT_INSERTION_DELAY = 2000;
+export const DEFAULT_ALLOW_UNPARSED = false;
 export const APP_NAME = name;
 
 export const opts = program
@@ -36,6 +37,7 @@ export const opts = program
   .addOption(new Option("--wait-for-async-insert <boolean>", "https://clickhouse.com/docs/en/operations/settings/settings#wait-for-async-insert").choices(["0", "1"]).env("WAIT_FOR_INSERT").default(DEFAULT_WAIT_FOR_ASYNC_INSERT))
   .addOption(new Option("--max-buffer-size <number>", "Maximum insertion batch size").env("MAX_BUFFER_SIZE").default(DEFAULT_MAX_BUFFER_SIZE))
   .addOption(new Option("--insertion-delay <number>", "Delay between batch insertions (in ms)").env("INSERTION_DELAY").default(DEFAULT_INSERTION_DELAY))
+  .addOption(new Option("--allow-unparsed <boolean>", "Enable storage in 'unparsed_json' table").choices(["true", "false"]).env("ALLOW_UNPARSED").default(DEFAULT_ALLOW_UNPARSED))
   .parse()
   .opts();
 

--- a/src/schemas.spec.ts
+++ b/src/schemas.spec.ts
@@ -20,6 +20,7 @@ const config = ConfigSchema.parse({
   asyncInsert: "1",
   maxBufferSize: "10000",
   insertionDelay: "2000",
+  allowUnparsed: true,
 });
 
 describe("ConfigSchema", () => {
@@ -34,4 +35,5 @@ describe("ConfigSchema", () => {
     ));
   test("waitForAsyncInsert", () => expect(config.waitForAsyncInsert).toBe(0));
   test("asyncInsert", () => expect(config.asyncInsert).toBe(1));
+  test("allowUnparsed", () => expect(config.allowUnparsed).toBeTrue());
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -22,6 +22,7 @@ export const ConfigSchema = z.object({
   waitForAsyncInsert: oneOrZero,
   maxBufferSize: positiveNumber,
   insertionDelay: positiveNumber,
+  allowUnparsed: boolean,
 });
 export type ConfigSchema = z.infer<typeof ConfigSchema>;
 


### PR DESCRIPTION
Added `--allow-unparsed` flag.

Did not modify the table engine to `Null` because it does not support `JSON` as a data type.