### PR TITLE
add 1s cache to `/health`

### DIFF
--- a/src/fetch/health.ts
+++ b/src/fetch/health.ts
@@ -2,16 +2,32 @@ import client from "../clickhouse/createClient.js";
 import { logger } from "../logger.js";
 import { BadRequest, toText } from "./cors.js";
 
+function now() {
+  return Math.floor(Date.now() / 1000); // seconds
+}
+
+// cache the timestamp and value for 1 seconds
+let timestamp = now();
+let value = true; // true = OK, false = ERROR
+
 export default async function () {
+  // return cached response if timestamp is less than 1 second old
+  if ( now() - timestamp < 1 ) {
+    return value ? toText("OK") : BadRequest;
+  }
+
   try {
     const response = await client.ping();
     if (!response.success) {
       throw new Error(response.error.message);
     }
-
+    timestamp = now();
+    value = true;
     return toText("OK");
   } catch (e) {
     logger.error(e);
+    timestamp = now();
+    value = false;
     return BadRequest;
   }
 }


### PR DESCRIPTION
```bash
$ oha http://localhost:3000/health -n 1000 -c 20
```
You can see doing multiple `/health`  GET requests currently can only serve 163 requests/second since it does "ping" on every request, regardless if the previous request was successful or not

![image](https://github.com/pinax-network/substreams-sink-clickhouse/assets/550895/64f4973f-8f64-456b-a80d-bd0fdb141a8e)

By adding a 1 second "cache" mechanism on the `/health` endpoint and we can achieve 88K requests/second :sweat_smile: 

542x improvement :laughing:  (obviously... would be a massive difference)

![image](https://github.com/pinax-network/substreams-sink-clickhouse/assets/550895/a26256ea-9b09-4cbb-816e-fc825f32bb8e)
