### PR TITLE
Reset caches

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@
 import { saveKnownEntityChanges } from "./src/clickhouse/handleSinkRequest.js";
 import { ping } from "./src/clickhouse/ping.js";
 import { config } from "./src/config.js";
+import DELETE from "./src/fetch/DELETE.js";
 import GET from "./src/fetch/GET.js";
 import OPTIONS from "./src/fetch/OPTIONS.js";
 import POST from "./src/fetch/POST.js";
@@ -29,6 +30,7 @@ const app = Bun.serve({
     if (req.method === "POST") return POST(req);
     if (req.method === "PUT") return PUT(req);
     if (req.method === "OPTIONS") return OPTIONS(req);
+    if (req.method === "DELETE") return DELETE(req);
     return NotFound;
   },
 });

--- a/src/clickhouse/stores.ts
+++ b/src/clickhouse/stores.ts
@@ -59,6 +59,12 @@ class ClickhouseStore {
     logger.info(`EXISTS [${table}=${exists}]`);
     return exists;
   }
+
+  public reset() {
+    this.chainsPromise = null;
+    this.publicTablesPromise = null;
+    this.knownTables.clear();
+  }
 }
 
 export const store = new ClickhouseStore();

--- a/src/fetch/DELETE.ts
+++ b/src/fetch/DELETE.ts
@@ -1,0 +1,17 @@
+import * as argon2 from "../auth/argon2.js";
+import { store } from "../clickhouse/stores.js";
+import { NotFound } from "./cors.js";
+
+export default async function (req: Request): Promise<Response> {
+  const { pathname } = new URL(req.url);
+
+  const error = argon2.beforeHandle(req);
+  if (error instanceof Response) return error;
+
+  if (pathname === "/caches") {
+    store.reset();
+    return new Response();
+  }
+
+  return NotFound;
+}

--- a/src/fetch/GET.ts
+++ b/src/fetch/GET.ts
@@ -6,7 +6,7 @@ import { blocks } from "./blocks.js";
 import { NotFound, toFile, toJSON } from "./cors.js";
 import { findCursorsForMissingBlocks, findLatestCursor } from "./cursors.js";
 import health from "./health.js";
-import openapi from "./openapi.js";
+import { openapi } from "./openapi.js";
 
 export default async function (req: Request) {
   const { pathname } = new URL(req.url);
@@ -15,7 +15,7 @@ export default async function (req: Request) {
   if (pathname === "/favicon.png") return toFile(file(swaggerFavicon));
   if (pathname === "/health") return health();
   if (pathname === "/metrics") return metrics();
-  if (pathname === "/openapi") return toJSON(openapi);
+  if (pathname === "/openapi") return toJSON(await openapi());
   if (pathname === "/blocks") return blocks();
   if (pathname === "/cursors/latest") return findLatestCursor(req);
   if (pathname === "/cursors/missing") return findCursorsForMissingBlocks(req);

--- a/src/fetch/openapi.ts
+++ b/src/fetch/openapi.ts
@@ -36,258 +36,273 @@ const PUT_RESPONSES: ResponsesObject = {
 
 const ExecuteSchemaResponse = z.object({ success: z.literal("OK"), schema: z.string() });
 
-export default new OpenApiBuilder()
-  .addInfo({
-    title: pkg.name,
-    version: pkg.version,
-    description: pkg.description,
-    license: {
-      name: pkg.license,
-      identifier: pkg.license,
-      url: `${pkg.homepage}/blob/main/LICENSE`,
-    } as LicenseObject,
-  })
-  .addExternalDocs({ url: pkg.homepage, description: "Extra documentation" })
-  .addSecurityScheme("auth-key", { type: "http", scheme: "bearer" })
-  .addPath("/init", {
-    put: {
-      tags: [TAGS.USAGE],
-      summary: "Initialize database & manifest",
-      security: [{ "auth-key": [] }],
-      responses: PUT_RESPONSES,
-    },
-  })
-  .addPath("/schema/sql", {
-    put: {
-      tags: [TAGS.USAGE],
-      summary: "Initialize the sink according to a SQL schema",
-      description:
-        "Supports `CREATE TABLE` statements<br/>If an url is passed in, the body will not be executed.",
-      security: [{ "auth-key": [] }],
-      parameters: [
-        { required: false, in: "query", name: "schema-url", schema: { type: "string" } },
-      ],
-      requestBody: {
-        content: {
-          "text/plain": {
-            schema: { type: "string" },
-            example: "CREATE TABLE foo (bar UInt32)\nENGINE = MergeTree\nORDER BY (bar)",
-          },
-          "application/octet-stream": {
-            schema: { type: "string", format: "base64" },
-          },
-        },
+export async function openapi() {
+  return new OpenApiBuilder()
+    .addInfo({
+      title: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      license: {
+        name: pkg.license,
+        identifier: pkg.license,
+        url: `${pkg.homepage}/blob/main/LICENSE`,
+      } as LicenseObject,
+    })
+    .addExternalDocs({ url: pkg.homepage, description: "Extra documentation" })
+    .addSecurityScheme("auth-key", { type: "http", scheme: "bearer" })
+    .addPath("/init", {
+      put: {
+        tags: [TAGS.USAGE],
+        summary: "Initialize database & manifest",
+        security: [{ "auth-key": [] }],
+        responses: PUT_RESPONSES,
       },
-      responses: {
-        ...PUT_RESPONSES,
-        200: {
-          description: "Success",
-          content: { "application/json": { schema: zodToJsonSchema(ExecuteSchemaResponse) } },
-        },
-      },
-    },
-  })
-  .addPath("/schema/graphql", {
-    put: {
-      tags: [TAGS.USAGE],
-      summary: "Initialize the sink according to a GraphQL schema",
-      description:
-        "Supports TheGraph's `@entity` statements. See https://thegraph.com/docs/en/querying/graphql-api/#entities<br/>If an url is passed in, the body will not be executed.",
-      externalDocs: {
-        description: "Valid data types",
-        url: "https://thegraph.com/docs/en/developing/creating-a-subgraph/#built-in-scalar-types",
-      },
-      security: [{ "auth-key": [] }],
-      parameters: [
-        { required: false, in: "query", name: "schema-url", schema: { type: "string" } },
-      ],
-      requestBody: {
-        content: {
-          "text/plain": {
-            schema: { type: "string" },
-            example: "type Foo @entity {\n\tid: ID!\n\tbar: BigInt\n}",
-          },
-          "application/octet-stream": {
-            schema: { type: "string", format: "base64" },
-          },
-        },
-      },
-      responses: {
-        ...PUT_RESPONSES,
-        200: {
-          description: "Success",
-          content: { "application/json": { schema: zodToJsonSchema(ExecuteSchemaResponse) } },
-        },
-      },
-    },
-  })
-  .addPath("/webhook", {
-    post: {
-      tags: [TAGS.USAGE],
-      summary: "Entry point for substreams-sink-webhook",
-      externalDocs: {
-        description: "substreams-sink-webhook",
-        url: "https://github.com/pinax-network/substreams-sink-webhook",
-      },
-      parameters: [
-        {
-          in: "header",
-          name: "x-signature-timestamp",
-          content: { "application/json": { schema: { type: "string" } } },
-        },
-        {
-          in: "header",
-          name: "x-signature-ed25519",
-          content: { "application/json": { schema: { type: "string" } } },
-        },
-      ],
-      requestBody: {
-        content: {
-          "application/json": { schema: zodToJsonSchema(BodySchema) },
-        },
-      },
-      responses: PUT_RESPONSES,
-    },
-  })
-  .addPath("/hash", {
-    post: {
-      tags: [TAGS.USAGE],
-      summary: "Generate a hash for a specified password",
-      requestBody: {
-        required: true,
-        description: "The password to hash",
-        content: { "text/plain": { schema: { type: "string" } } },
-      },
-      responses: {
-        200: { description: "Success", content: { "text/plain": { schema: { type: "string" } } } },
-      },
-    },
-  })
-  .addPath("/pause", {
-    put: {
-      tags: [TAGS.MAINTENANCE],
-      security: [{ "auth-key": [] }],
-      summary: "Blocks all incoming requests to `/webhook` until unpaused",
-      responses: { 200: { description: "Success" } },
-    },
-  })
-  .addPath("/unpause", {
-    put: {
-      tags: [TAGS.MAINTENANCE],
-      security: [{ "auth-key": [] }],
-      summary: "Resumes listening to requests on `/webhook`",
-      responses: { 200: { description: "Success" } },
-    },
-  })
-  .addPath("/caches", {
-    delete: {
-      tags: [TAGS.MAINTENANCE],
-      security: [{ "auth-key": [] }],
-      summary: "Clears table and chain caches",
-      responses: { 200: { description: "Success" } },
-    },
-  })
-  .addPath("/cursors/latest", {
-    get: {
-      tags: [TAGS.QUERIES],
-      summary: "Finds the latest cursor for a given chain and table",
-      parameters: [
-        { name: "chain", in: "query", required: true, schema: { enum: await store.chains } },
-        { name: "table", in: "query", required: true, schema: { enum: await store.publicTables } },
-      ],
-      responses: {
-        200: {
-          description: "Success",
+    })
+    .addPath("/schema/sql", {
+      put: {
+        tags: [TAGS.USAGE],
+        summary: "Initialize the sink according to a SQL schema",
+        description:
+          "Supports `CREATE TABLE` statements<br/>If an url is passed in, the body will not be executed.",
+        security: [{ "auth-key": [] }],
+        parameters: [
+          { required: false, in: "query", name: "schema-url", schema: { type: "string" } },
+        ],
+        requestBody: {
           content: {
-            "application/json": {
-              schema: zodToJsonSchema(z.object({ cursor: z.string(), timestamp: z.string() })),
+            "text/plain": {
+              schema: { type: "string" },
+              example: "CREATE TABLE foo (bar UInt32)\nENGINE = MergeTree\nORDER BY (bar)",
+            },
+            "application/octet-stream": {
+              schema: { type: "string", format: "base64" },
             },
           },
         },
-        400: PUT_RESPONSES[400],
+        responses: {
+          ...PUT_RESPONSES,
+          200: {
+            description: "Success",
+            content: { "application/json": { schema: zodToJsonSchema(ExecuteSchemaResponse) } },
+          },
+        },
       },
-    },
-  })
-  .addPath("/cursors/missing", {
-    get: {
-      tags: [TAGS.QUERIES],
-      summary: "Finds the missing blocks and returns the start and end cursors",
-      parameters: [
-        { name: "chain", in: "query", required: true, schema: { enum: await store.chains } },
-        { name: "table", in: "query", required: true, schema: { enum: await store.publicTables } },
-      ],
-      responses: {
-        200: {
-          description: "Success",
+    })
+    .addPath("/schema/graphql", {
+      put: {
+        tags: [TAGS.USAGE],
+        summary: "Initialize the sink according to a GraphQL schema",
+        description:
+          "Supports TheGraph's `@entity` statements. See https://thegraph.com/docs/en/querying/graphql-api/#entities<br/>If an url is passed in, the body will not be executed.",
+        externalDocs: {
+          description: "Valid data types",
+          url: "https://thegraph.com/docs/en/developing/creating-a-subgraph/#built-in-scalar-types",
+        },
+        security: [{ "auth-key": [] }],
+        parameters: [
+          { required: false, in: "query", name: "schema-url", schema: { type: "string" } },
+        ],
+        requestBody: {
           content: {
-            "application/json": {
-              schema: zodToJsonSchema(
-                z.array(
-                  z.object({
-                    from: z.object({ block: z.number(), cursor: z.string() }),
-                    to: z.object({ block: z.number(), cursor: z.string() }),
-                  })
-                )
-              ),
+            "text/plain": {
+              schema: { type: "string" },
+              example: "type Foo @entity {\n\tid: ID!\n\tbar: BigInt\n}",
+            },
+            "application/octet-stream": {
+              schema: { type: "string", format: "base64" },
             },
           },
         },
-        400: PUT_RESPONSES[400],
+        responses: {
+          ...PUT_RESPONSES,
+          200: {
+            description: "Success",
+            content: { "application/json": { schema: zodToJsonSchema(ExecuteSchemaResponse) } },
+          },
+        },
       },
-    },
-  })
-  .addPath("/blocks", {
-    get: {
-      tags: [TAGS.QUERIES],
-      summary: "Gives a summary of known blocks, including min, max and unique block numbers",
-      responses: {
-        200: {
-          description: "Block number summary",
+    })
+    .addPath("/webhook", {
+      post: {
+        tags: [TAGS.USAGE],
+        summary: "Entry point for substreams-sink-webhook",
+        externalDocs: {
+          description: "substreams-sink-webhook",
+          url: "https://github.com/pinax-network/substreams-sink-webhook",
+        },
+        parameters: [
+          {
+            in: "header",
+            name: "x-signature-timestamp",
+            content: { "application/json": { schema: { type: "string" } } },
+          },
+          {
+            in: "header",
+            name: "x-signature-ed25519",
+            content: { "application/json": { schema: { type: "string" } } },
+          },
+        ],
+        requestBody: {
           content: {
-            "application/json": {
-              schema: zodToJsonSchema(BlockResponseSchema),
+            "application/json": { schema: zodToJsonSchema(BodySchema) },
+          },
+        },
+        responses: PUT_RESPONSES,
+      },
+    })
+    .addPath("/hash", {
+      post: {
+        tags: [TAGS.USAGE],
+        summary: "Generate a hash for a specified password",
+        requestBody: {
+          required: true,
+          description: "The password to hash",
+          content: { "text/plain": { schema: { type: "string" } } },
+        },
+        responses: {
+          200: {
+            description: "Success",
+            content: { "text/plain": { schema: { type: "string" } } },
+          },
+        },
+      },
+    })
+    .addPath("/pause", {
+      put: {
+        tags: [TAGS.MAINTENANCE],
+        security: [{ "auth-key": [] }],
+        summary: "Blocks all incoming requests to `/webhook` until unpaused",
+        responses: { 200: { description: "Success" } },
+      },
+    })
+    .addPath("/unpause", {
+      put: {
+        tags: [TAGS.MAINTENANCE],
+        security: [{ "auth-key": [] }],
+        summary: "Resumes listening to requests on `/webhook`",
+        responses: { 200: { description: "Success" } },
+      },
+    })
+    .addPath("/caches", {
+      delete: {
+        tags: [TAGS.MAINTENANCE],
+        security: [{ "auth-key": [] }],
+        summary: "Clears table and chain caches",
+        responses: { 200: { description: "Success" } },
+      },
+    })
+    .addPath("/cursors/latest", {
+      get: {
+        tags: [TAGS.QUERIES],
+        summary: "Finds the latest cursor for a given chain and table",
+        parameters: [
+          { name: "chain", in: "query", required: true, schema: { enum: await store.chains } },
+          {
+            name: "table",
+            in: "query",
+            required: true,
+            schema: { enum: await store.publicTables },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: zodToJsonSchema(z.object({ cursor: z.string(), timestamp: z.string() })),
+              },
+            },
+          },
+          400: PUT_RESPONSES[400],
+        },
+      },
+    })
+    .addPath("/cursors/missing", {
+      get: {
+        tags: [TAGS.QUERIES],
+        summary: "Finds the missing blocks and returns the start and end cursors",
+        parameters: [
+          { name: "chain", in: "query", required: true, schema: { enum: await store.chains } },
+          {
+            name: "table",
+            in: "query",
+            required: true,
+            schema: { enum: await store.publicTables },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: zodToJsonSchema(
+                  z.array(
+                    z.object({
+                      from: z.object({ block: z.number(), cursor: z.string() }),
+                      to: z.object({ block: z.number(), cursor: z.string() }),
+                    })
+                  )
+                ),
+              },
+            },
+          },
+          400: PUT_RESPONSES[400],
+        },
+      },
+    })
+    .addPath("/blocks", {
+      get: {
+        tags: [TAGS.QUERIES],
+        summary: "Gives a summary of known blocks, including min, max and unique block numbers",
+        responses: {
+          200: {
+            description: "Block number summary",
+            content: {
+              "application/json": {
+                schema: zodToJsonSchema(BlockResponseSchema),
+              },
+            },
+          },
+          500: { description: "Internal server errror" },
+        },
+      },
+    })
+    .addPath("/query", {
+      post: {
+        tags: [TAGS.QUERIES],
+        summary: "Execute queries against the database in read-only mode",
+        requestBody: {
+          content: {
+            "text/plain": {
+              schema: { type: "string", examples: ["SELECT COUNT() FROM blocks"] },
             },
           },
         },
-        500: { description: "Internal server errror" },
+        responses: { 200: { description: "query result", content: { "application/json": {} } } },
       },
-    },
-  })
-  .addPath("/query", {
-    post: {
-      tags: [TAGS.QUERIES],
-      summary: "Execute queries against the database in read-only mode",
-      requestBody: {
-        content: {
-          "text/plain": {
-            schema: { type: "string", examples: ["SELECT COUNT() FROM blocks"] },
-          },
+    })
+    .addPath("/health", {
+      get: {
+        tags: [TAGS.HEALTH],
+        summary: "Performs health checks and checks if the database is accessible",
+        responses: { 200: PUT_RESPONSES[200] },
+      },
+    })
+    .addPath("/metrics", {
+      get: {
+        tags: [TAGS.HEALTH],
+        summary: "Prometheus metrics",
+        responses: { 200: { description: "Prometheus metrics" } },
+      },
+    })
+    .addPath("/openapi", {
+      get: {
+        tags: [TAGS.DOCS],
+        summary: "OpenAPI specification",
+        responses: {
+          200: { description: "OpenAPI specification JSON", content: { "application/json": {} } },
         },
       },
-      responses: { 200: { description: "query result", content: { "application/json": {} } } },
-    },
-  })
-  .addPath("/health", {
-    get: {
-      tags: [TAGS.HEALTH],
-      summary: "Performs health checks and checks if the database is accessible",
-      responses: { 200: PUT_RESPONSES[200] },
-    },
-  })
-  .addPath("/metrics", {
-    get: {
-      tags: [TAGS.HEALTH],
-      summary: "Prometheus metrics",
-      responses: { 200: { description: "Prometheus metrics" } },
-    },
-  })
-  .addPath("/openapi", {
-    get: {
-      tags: [TAGS.DOCS],
-      summary: "OpenAPI specification",
-      responses: {
-        200: { description: "OpenAPI specification JSON", content: { "application/json": {} } },
-      },
-    },
-  })
-  .getSpecAsJson();
+    })
+    .getSpecAsJson();
+}

--- a/src/fetch/schema.ts
+++ b/src/fetch/schema.ts
@@ -1,3 +1,4 @@
+import { store } from "../clickhouse/stores.js";
 import { initializeTables } from "../clickhouse/table-initialization.js";
 import { splitSchemaByTableCreation } from "../clickhouse/table-utils.js";
 import { ClickhouseTableBuilder } from "../graphql/builders/clickhouse-table-builder.js";
@@ -25,6 +26,7 @@ export async function handleSchemaRequest(req: Request, type: "sql" | "graphql")
 
   try {
     const executedSchemas = await initializeTables(tableSchemas);
+    store.reset();
     return toJSON({ status: "OK", schema: executedSchemas.join("\n\n") });
   } catch (err) {
     logger.error(err);


### PR DESCRIPTION
Added `DELETE /caches` endpoint to clear the `knownTables` and `knownChains` caches.
This will be reflected in Swagger by refreshing the page.

The caches are also automatically resetted when a new table is created via `/schema/sql` or `/schema/graphql`.