### PR TITLE
fix blocks SQL

### DIFF
--- a/sql/blocks.ts
+++ b/sql/blocks.ts
@@ -40,10 +40,11 @@ export async function blocks(req: Request) {
   const chain = getChain(req, false);
   const module_hash = getModuleHash(req, false);
   const WHERE = [];
-  if ( chain ) WHERE.push(`chain = ${chain}`);
-  if ( module_hash ) WHERE.push(`module_hash = ${module_hash}`);
+  if ( chain ) WHERE.push(`chain = '${chain}'`);
+  if ( module_hash ) WHERE.push(`module_hash = '${module_hash}'`);
   if ( WHERE.length ) query += " WHERE " + WHERE.join(" AND ");
-  query += "GROUP BY (chain, module_hash)";
+  query += "\nGROUP BY (chain, module_hash)";
+  console.log(query);
 
   const response = await readOnlyClient.query({ query_params: {chain, module_hash}, query, format: "JSONEachRow" });
   let data = await response.json() as BlockResponseSchema[];


### PR DESCRIPTION
Solves issue for:

"""
/blocks (e.g. /blocks?chain=eos&module_hash=<...>) fails with this error
Error: Syntax error: failed at position 370 ('BY') (line 12, col 84): BY (chain, module_hash) 
FORMAT JSONEachRow. Expected one of: token, Dot, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS, GROUP BY, WITH, HAVING, WINDOW, ORDER BY, LIMIT, OFFSET, FETCH, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query. 
"""